### PR TITLE
optimised embedding

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -7,7 +7,7 @@ from tricycle.einsum import Einsum
 from tricycle.layers import (  # noqa: E501
     Dense,
     Dropout,
-    Embedding,
+    EmbeddingV2,
     LayerNorm,
     RMSNorm,
     Sequential,
@@ -66,7 +66,7 @@ def test_dropout():  # sourcery skip: square-identity
     assert in_tensor.grad is not None
     assert in_tensor.grad.shape == in_tensor.shape
 
-    coef = 1 / (1-dropout_prob)
+    coef = 1 / (1 - dropout_prob)
     correct_grad = np.full(in_tensor.shape, coef)
     correct_grad[zero_x_idx, zero_y_idx] = 0
 
@@ -102,7 +102,7 @@ def test_embedding():
         dtype=int,
     )
 
-    embedding_layer = Embedding(from_size=vocab_size, to_size=out_shape)
+    embedding_layer = EmbeddingV2(from_size=vocab_size, to_size=out_shape)
     weights = np.indices((vocab_size * out_shape,)).reshape(
         vocab_size, out_shape
     )
@@ -135,7 +135,7 @@ def test_embedding_vectorised():
         dtype=np.int8,
     ).to_vector()
 
-    embedding_layer = Embedding(from_size=vocab_size, to_size=out_shape)
+    embedding_layer = EmbeddingV2(from_size=vocab_size, to_size=out_shape)
     weights = np.indices((vocab_size * out_shape,)).reshape(
         vocab_size, out_shape
     )


### PR DESCRIPTION
The embedding layer has been optimsed and is now ~8.5x faster! 
I ran this benchmark:
```python
import numpy as np

from tricycle.layers import Embedding, EmbeddingV2
from tricycle.tensor import to_tensor

N_LOOPS = 100
DEVICE = 1


def test_embedding_original():
    np.random.seed(0)
    x = np.random.randint(0, 64, size=64)
    x = to_tensor(x, is_vector=True, requires_grad=False, dtype=int)
    x.to_gpu(DEVICE)

    layer = Embedding(from_size=64, to_size=1024)
    layer.to_gpu(DEVICE)

    for _ in range(N_LOOPS):
        out = layer(x)
        out.backward()


def test_embedding_new():
    np.random.seed(0)
    x = np.random.randint(0, 64, size=64)
    x = to_tensor(x, is_vector=True, requires_grad=False, dtype=int)
    x.to_gpu(DEVICE)

    layer = EmbeddingV2(from_size=64, to_size=1024)
    layer.to_gpu(DEVICE)

    for _ in range(N_LOOPS):
        out = layer(x)
        out.backward()


__benchmarks__ = [(test_embedding_original, test_embedding_new, "original")]
```

And richbench gave this:
```

┏━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ Benchmark ┃ Min     ┃ Max     ┃ Mean    ┃ Min (+)         ┃ Max (+)         ┃ Mean (+)        ┃
┡━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│  original │ 0.677   │ 0.744   │ 0.692   │ 0.080 (8.5x)    │ 0.081 (9.2x)    │ 0.080 (8.6x)    │
└───────────┴─────────┴─────────┴─────────┴─────────────────┴─────────────────┴─────────────────┘
```

The main changes were simply removing python lists and replacing them with proper vectorised operations.